### PR TITLE
Fix repo name in Rake task to use CircleCI environment variables

### DIFF
--- a/lib/ablecop/tasks/ablecop.rake
+++ b/lib/ablecop/tasks/ablecop.rake
@@ -40,7 +40,7 @@ namespace :ablecop do
 end
 
 def post_status(state, message)
-  repo = "ableco/core.able.co"
+  repo = ENV["CIRCLE_PROJECT_USERNAME"] + "/" + ENV["CIRCLE_PROJECT_REPONAME"]
   sha = ENV["CIRCLE_SHA1"]
 
   options = {


### PR DESCRIPTION
The Rake task to run Pronto's code runners in CircleCI had the C- project repo hard-coded, which is causing problems with other projects. This branch fixes it by using CircleCI's [environment variables](https://circleci.com/docs/environment-variables/).

Closes #7.
