### PR TITLE
Set Rubocop's TargetRubyVersion to 2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # AbleCop Changelog
 
+## Untagged
+
+- Set Rubocop's `TargetRubyVersion` to `2.2`.
+
 ## 0.3.1
 
 - Bug fix: Use CircleCI's environment variables to set up the appropriate GitHub repo when running the `ablecop:run_on_circleci` Rake task.

--- a/config/.rubocop.yml
+++ b/config/.rubocop.yml
@@ -61,7 +61,7 @@ AllCops:
   CacheRootDirectory: /tmp
   # What version of the Ruby interpreter is the inspected code intended to
   # run on? (If there is more than one, set this to the lowest version.)
-  TargetRubyVersion: 2.0
+  TargetRubyVersion: 2.2
 
 # Indent private/protected/public as deep as method definitions
 Style/AccessModifierIndentation:


### PR DESCRIPTION
This branch updates the default Rubocop configuration to set the `TargetRubyVersion` option to 2.2, since most (if not all) of our active projects using AbleCop are using Ruby 2.2 or Ruby 2.3.

More information about this configuration option can be found [here](https://github.com/bbatsov/rubocop#setting-the-target-ruby-version).
