### PR TITLE
Update existing files in .gitignore to only ignore AbleCop's files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # AbleCop Changelog
 
+## Untagged
+
+- Add method to ensure that the project's `.gitignore` file includes only AbleCop's configuration files, as opposed to ignoring all files of the same name (which includes the project's override files).
+
 ## 0.3.1
 
 - Bug fix: Use CircleCI's environment variables to set up the appropriate GitHub repo when running the `ablecop:run_on_circleci` Rake task.

--- a/spec/lib/ablecop/generators/install_generator_spec.rb
+++ b/spec/lib/ablecop/generators/install_generator_spec.rb
@@ -38,19 +38,19 @@ describe Ablecop::InstallGenerator, type: :generator do
       end
 
       it "adds '.rubocop.yml' to the project's .gitignore" do
-        expect(File.readlines(gitignore_file)).to include(/^.rubocop.yml$/)
+        expect(File.readlines(gitignore_file)).to include(%r{^/.rubocop.yml$})
       end
 
       it "adds '.fasterer.yml' to the project's .gitignore" do
-        expect(File.readlines(gitignore_file)).to include(/^.fasterer.yml$/)
+        expect(File.readlines(gitignore_file)).to include(%r{^/.fasterer.yml$})
       end
 
       it "adds '.scss-lint.yml' to the project's .gitignore" do
-        expect(File.readlines(gitignore_file)).to include(/^.scss-lint.yml$/)
+        expect(File.readlines(gitignore_file)).to include(%r{^/.scss-lint.yml$})
       end
 
       it "adds 'config/rails_best_practices.yml' to the project's .gitignore" do
-        expect(File.readlines(gitignore_file)).to include(%r{^config/rails_best_practices.yml$})
+        expect(File.readlines(gitignore_file)).to include(%r{^/config/rails_best_practices.yml$})
       end
     end
 
@@ -73,6 +73,36 @@ describe Ablecop::InstallGenerator, type: :generator do
     end
 
     it "raises a ConfigFileError if the configuration file was not copied"
+  end
+
+  context "checking existing files in .gitignore" do
+    let(:gitignore_file) { File.expand_path(".gitignore", destination_root) }
+
+    before(:all) do
+      prepare_destination
+      File.open("#{destination_root}/.gitignore", "w") { |f| f.write(".fasterer.yml\n.rubocop.yml\n.scss-lint.yml\nconfig\/rails_best_practices.yml\n") }
+      run_generator
+    end
+
+    it "updates '.rubocop.yml' to '/.rubocop.yml' in the project's .gitignore if it exists" do
+      expect(File.readlines(gitignore_file)).to_not include(/^.rubocop.yml$/)
+      expect(File.readlines(gitignore_file)).to include(%r{^/.rubocop.yml$})
+    end
+
+    it "adds '.fasterer.yml' to '/.fasterer.yml' in the project's .gitignore if it exists" do
+      expect(File.readlines(gitignore_file)).to_not include(/^.fasterer.yml$/)
+      expect(File.readlines(gitignore_file)).to include(%r{^/.fasterer.yml$})
+    end
+
+    it "adds '.scss-lint.yml' to './scss-lint.yml' in the project's .gitignore if it exists" do
+      expect(File.readlines(gitignore_file)).to_not include(/^.scss-lint.yml$/)
+      expect(File.readlines(gitignore_file)).to include(%r{^/.scss-lint.yml$})
+    end
+
+    it "adds 'config/rails_best_practices.yml' to '/config/rails_best_practices.yml' in the project's .gitignore if it exists" do
+      expect(File.readlines(gitignore_file)).to_not include(%r{^config/rails_best_practices.yml$})
+      expect(File.readlines(gitignore_file)).to include(%r{^/config/rails_best_practices.yml$})
+    end
   end
 
   context "overriding default configuration files" do


### PR DESCRIPTION
This branch adds a check to AbleCop's install generator to make sure that the files we add to a project's `.gitignore` are the ones that AbleCop sets up, by making sure we explicitly set the project's root for the file. This is a convenience method so that projects already using AbleCop don't need to have `.gitignore` manually updated.

This was done thanks to @juliogarciag pointing out that the overrides - which are now the same name as the original configuration files - are being ignored because `.gitignore` just has the filename. For example, because `.gitignore` includes `.rubocop.yml`, this would ignore both `.rubocop.yml` in the root of the project as well as `config/ablecop/.rubocop.yml`, which we want to keep. Now, those filenames in `.gitignore` will make sure to only look at the files based on the root of the project (`/.rubocop.yml`).
