### PR TITLE
Bug fix for updating project's .gitignore file if necessary

### DIFF
--- a/lib/ablecop/generators/install_generator.rb
+++ b/lib/ablecop/generators/install_generator.rb
@@ -82,12 +82,10 @@ module Ablecop
       gitignore_file = File.expand_path(".gitignore", destination_root)
       return unless File.exist?(gitignore_file)
 
-      config_files = CONFIGURATION_FILES.map do |file_name, destination|
-        "#{destination}/#{file_name}".gsub("./", "").tr("/", "\/")
-      end.join("|")
-
-      gsub_file gitignore_file, /^#{config_files}$/ do |match|
-        "/#{match}"
+      CONFIGURATION_FILES.each do |file_name, destination|
+        file = "#{destination}/#{file_name}".gsub("./", "").tr("/", "\/")
+        next unless File.readlines(gitignore_file).any? { |line| line.strip == file }
+        gsub_file(gitignore_file, /^(#{file})$/, "/#{file}")
       end
     end
 

--- a/spec/lib/ablecop/generators/install_generator_spec.rb
+++ b/spec/lib/ablecop/generators/install_generator_spec.rb
@@ -89,19 +89,45 @@ describe Ablecop::InstallGenerator, type: :generator do
       expect(File.readlines(gitignore_file)).to include(%r{^/.rubocop.yml$})
     end
 
-    it "adds '.fasterer.yml' to '/.fasterer.yml' in the project's .gitignore if it exists" do
+    it "updates '.fasterer.yml' to '/.fasterer.yml' in the project's .gitignore if it exists" do
       expect(File.readlines(gitignore_file)).to_not include(/^.fasterer.yml$/)
       expect(File.readlines(gitignore_file)).to include(%r{^/.fasterer.yml$})
     end
 
-    it "adds '.scss-lint.yml' to './scss-lint.yml' in the project's .gitignore if it exists" do
+    it "updates '.scss-lint.yml' to './scss-lint.yml' in the project's .gitignore if it exists" do
       expect(File.readlines(gitignore_file)).to_not include(/^.scss-lint.yml$/)
       expect(File.readlines(gitignore_file)).to include(%r{^/.scss-lint.yml$})
     end
 
-    it "adds 'config/rails_best_practices.yml' to '/config/rails_best_practices.yml' in the project's .gitignore if it exists" do
+    it "updates 'config/rails_best_practices.yml' to '/config/rails_best_practices.yml' in the project's .gitignore if it exists" do
       expect(File.readlines(gitignore_file)).to_not include(%r{^config/rails_best_practices.yml$})
       expect(File.readlines(gitignore_file)).to include(%r{^/config/rails_best_practices.yml$})
+    end
+  end
+
+  context "checking existing files in .gitignore that don't need to be updated" do
+    let(:gitignore_file) { File.expand_path(".gitignore", destination_root) }
+
+    before(:all) do
+      prepare_destination
+      File.open("#{destination_root}/.gitignore", "w") { |f| f.write("/.fasterer.yml\n/.rubocop.yml\n/.scss-lint.yml\n/config\/rails_best_practices.yml\n") }
+      run_generator
+    end
+
+    it "includes '.rubocop.yml' once in the project's .gitignore" do
+      expect(File.read(gitignore_file).scan(/.rubocop.yml/).length).to eq(1)
+    end
+
+    it "includes '.fasterer.yml' once in the project's .gitignore" do
+      expect(File.read(gitignore_file).scan(/.fasterer.yml/).length).to eq(1)
+    end
+
+    it "includes '.scss-lint.yml' once in the project's .gitignore" do
+      expect(File.read(gitignore_file).scan(/.scss-lint.yml/).length).to eq(1)
+    end
+
+    it "includes 'config/rails_best_practices.yml' once in the project's .gitignore" do
+      expect(File.read(gitignore_file).scan(%r{config/rails_best_practices.yml}).length).to eq(1)
     end
   end
 


### PR DESCRIPTION
Pull request #10 added an additional method to the generator to check if we should update the project's `.gitignore` to ensure we're only ignoring AbleCop's configuration files. This was not working as expected, as it was not doing the substitution correctly on subsequent runs. Regex is hard :crying_cat_face: 

This branch should fix the issue by checking the files individually. This is just a temporary method and will be removed in the future after all projects have updated to this version of the gem, so it doesn't need to be optimized in any way. I also wrote specs to ensure that the files are only being included once just to make sure this doesn't slip past by me again.
