### PR TITLE
Add fasterer check to CircleCI

### DIFF
--- a/.fasterer.yml
+++ b/.fasterer.yml
@@ -1,0 +1,22 @@
+speedups:
+  rescue_vs_respond_to: true
+  module_eval: true
+  shuffle_first_vs_sample: true
+  for_loop_vs_each: true
+  each_with_index_vs_while: true
+  map_flatten_vs_flat_map: true
+  reverse_each_vs_reverse_each: true
+  select_first_vs_detect: true
+  sort_vs_sort_by: true
+  fetch_with_argument_vs_block: true
+  keys_each_vs_each_key: true
+  hash_merge_bang_vs_hash_brackets: true
+  block_vs_symbol_to_proc: true
+  proc_call_vs_yield: true
+  gsub_vs_tr: true
+  select_last_vs_reverse_detect: true
+  getter_vs_attr_reader: true
+  setter_vs_attr_writer: true
+
+exclude_paths:
+  - 'vendor/**/*.rb'

--- a/circle.yml
+++ b/circle.yml
@@ -2,3 +2,4 @@ test:
   override:
     - bundle exec rake spec
     - bundle exec rubocop
+    - bundle exec fasterer


### PR DESCRIPTION
This branch adds the command to run [fasterer](https://github.com/DamirSvrtan/fasterer) in our CircleCI builds. I also set the configuration file in the root of the repo, since we can't specify the configuration file in the command, and we also need to exclude bundled gems on CircleCI.
