### PR TITLE
Ensure Brakeman runner is loaded last when loading Pronto runners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # AbleCop Changelog
 
+## Unreleased
+
+- Ensure [pronto-brakeman](https://github.com/mmozuras/pronto-brakeman) is loaded last to deal with bug related to load order (#20)
+
 ## 0.3.2
 
 - Set Rubocop's `TargetRubyVersion` to `2.2`. (#9)

--- a/lib/ablecop/tasks/ablecop.rake
+++ b/lib/ablecop/tasks/ablecop.rake
@@ -7,7 +7,7 @@ namespace :ablecop do
   task :run_on_circleci do
     abort("Github access token is missing") unless ENV["GITHUB_ACCESS_TOKEN"].present?
 
-    Pronto::GemNames.new.to_a.each { |gem_name| require "pronto/#{gem_name}" }
+    require_pronto_runners
 
     # If CircleCI includes the pull request information, run the code analysis on the
     # branch for the pull request.
@@ -33,7 +33,7 @@ namespace :ablecop do
 
   desc "Run code analysis between the current HEAD and master"
   task :run do
-    Pronto::GemNames.new.to_a.each { |gem_name| require "pronto/#{gem_name}" }
+    require_pronto_runners
     formatter = Pronto::Formatter::TextFormatter.new
     Pronto.run("origin/master", ".", formatter)
   end
@@ -51,4 +51,15 @@ def post_status(state, message)
 
   Octokit.access_token = ENV["GITHUB_ACCESS_TOKEN"]
   Octokit.create_status(repo, sha, state, options)
+end
+
+# There's an issue with Pronto when running the Brakeman and rails_best_practices
+# runners in a specific order (https://github.com/mmozuras/pronto/issues/80). If
+# Brakeman is loaded before rails_best_practices, it can raise false positives.
+# This method will make sure that Brakeman is loaded last when loading the Pronto
+# runners.
+def require_pronto_runners
+  gem_names = Pronto::GemNames.new.to_a
+  gem_names.push(gem_names.delete("brakeman")) if gem_names.include?("brakeman")
+  gem_names.each { |gem_name| require "pronto/#{gem_name}" }
 end


### PR DESCRIPTION
There's an [issue with Pronto](https://github.com/mmozuras/pronto/issues/80) when running the Brakeman and rails_best_practices runners in a specific order. If Brakeman is loaded before rails_best_practices, it can raise false positives (as seen [here](https://github.com/ableco/core.able.co/pull/579#discussion_r64143175) and [here](https://github.com/ableco/core.able.co/pull/574#commitcomment-17660584))

Neither Pronto nor Brakeman don't have a fix for this yet, so in the meantime I modified the way the Pronto loads the runners by making sure that the Brakeman runner is loaded last. I tested this modification on those specific branches I mentioned and it worked well - the false positives were not triggered. As soon as Pronto or Brakeman release an update that fixes this issue, I'll remove this method.
