### PR TITLE
Set DuplicateProperty scss-lint rule to `ignore_consecutive: true`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # AbleCop Changelog
 
+## Unreleased
+
+- **scss-lint**: Update the [DuplicateProperty](https://github.com/brigade/scss-lint/blob/master/lib/scss_lint/linter/README.md#duplicateproperty) rule to `ignore_consecutive: true`.
+
 ## 0.3.3
 
 - Ensure [pronto-brakeman](https://github.com/mmozuras/pronto-brakeman) is loaded last to deal with bug related to load order (#20)

--- a/config/.scss-lint.yml
+++ b/config/.scss-lint.yml
@@ -46,7 +46,7 @@ linters:
     enabled: false
 
   DuplicateProperty:
-    enabled: true
+    ignore_consecutive: true
 
   ElsePlacement:
     enabled: true


### PR DESCRIPTION
In our default scss-lint configuration, we have the `DuplicateProperty` rule enabled ([scss-lint docs](https://github.com/brigade/scss-lint/blob/master/lib/scss_lint/linter/README.md#duplicateproperty)). This is causing issues with some cases where it's acceptable / necessary to have duplicate properties in a CSS rule, like for writing fallbacks in case browsers don't support specific functionality.

To handle these issues, I changed the `DuplicateProperty` rule to be `ignore_consecutive: true`. This will allow us to write duplicate properties in places where we need them, only when they're written in consecutive lines (which should make it easier for a code reviewer to spot).

@mpotter Since you set the default configuration for scss-lint in this repo, was there a reason for having that rule enabled? I'm guessing not and it was just because it's in the [default configuration file in the repo](https://github.com/brigade/scss-lint/blob/master/config/default.yml), but please chime in if there was another reason!

Closes #22.
