### PR TITLE
Upgrade Brakeman gem to 3.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - **scss-lint**: Update the [DuplicateProperty](https://github.com/brigade/scss-lint/blob/master/lib/scss_lint/linter/README.md#duplicateproperty) rule to `ignore_consecutive: true`.
+- **brakeman**: Upgraded to [3.3.2](http://brakemanscanner.org/blog/2016/06/10/brakeman-3-dot-3-2-released/).
 
 ## 0.3.3
 

--- a/ablecop.gemspec
+++ b/ablecop.gemspec
@@ -55,7 +55,7 @@ MSG
   spec.add_dependency "pronto-rubocop", "~> 0.6.2"
 
   # Brakeman scans for security vulenerabilities.
-  spec.add_dependency "brakeman", "~> 3.3.0"
+  spec.add_dependency "brakeman", "~> 3.3.2"
   spec.add_dependency "pronto-brakeman", "~> 0.6.0"
 
   # Fasterer will suggest some speed improvements.


### PR DESCRIPTION
This branch upgrades the Brakeman gem to [3.3.2](http://brakemanscanner.org/blog/2016/06/10/brakeman-3-dot-3-2-released/), which fixes a performance regression. It also includes the changes from [3.3.1](http://brakemanscanner.org/blog/2016/06/03/brakeman-3-dot-3-1-released/).
