### PR TITLE
Update Pronto to 0.7.1, update all associated runners / libraries and clean up unnecessary code

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
 source "https://rubygems.org"
+ruby "2.3.1"
 gemspec

--- a/ablecop.gemspec
+++ b/ablecop.gemspec
@@ -35,7 +35,7 @@ test:
 
 MSG
 
-  spec.required_ruby_version = '>= 2.2.0'
+  spec.required_ruby_version = ">= 2.2.0"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/ablecop.gemspec
+++ b/ablecop.gemspec
@@ -35,6 +35,8 @@ test:
 
 MSG
 
+  spec.required_ruby_version = '>= 2.2.0'
+
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/ablecop.gemspec
+++ b/ablecop.gemspec
@@ -45,31 +45,31 @@ MSG
   spec.add_dependency "deep_merge", "~> 1.0.1"
 
   # Pronto posts feedback from its runners to Github.
-  spec.add_dependency "pronto", "~> 0.6.0"
+  spec.add_dependency "pronto", "~> 0.7.1"
 
   # Octokit is required for updating commits / pull requests.
   spec.add_dependency "octokit", "~> 4.3.0"
 
   # Rubocop is a static code analyzer based on our Ruby style guide.
-  spec.add_dependency "rubocop", "~> 0.40.0"
-  spec.add_dependency "pronto-rubocop", "~> 0.6.2"
+  spec.add_dependency "rubocop", "~> 0.42.0"
+  spec.add_dependency "pronto-rubocop", "~> 0.7.0"
 
   # Brakeman scans for security vulenerabilities.
-  spec.add_dependency "brakeman", "~> 3.3.2"
-  spec.add_dependency "pronto-brakeman", "~> 0.6.0"
+  spec.add_dependency "brakeman", "~> 3.3.5"
+  spec.add_dependency "pronto-brakeman", "~> 0.7.0"
 
   # Fasterer will suggest some speed improvements.
   spec.add_dependency "fasterer", "~> 0.3.2"
-  spec.add_dependency "pronto-fasterer", "~> 0.6.1"
+  spec.add_dependency "pronto-fasterer", "~> 0.7.0"
 
   # SCSS Lint is a static code analyzer based on our SCSS style guide.
-  spec.add_dependency "scss_lint", "~> 0.48.0"
-  spec.add_dependency "pronto-scss", "~> 0.6.0"
+  spec.add_dependency "scss_lint", "~> 0.49.0"
+  spec.add_dependency "pronto-scss", "~> 0.7.0"
 
   # Pronto runner for monitoring Rails schema.rb or structure.sql consistency.
-  spec.add_dependency "pronto-rails_schema", "~> 0.6.0"
+  spec.add_dependency "pronto-rails_schema", "~> 0.7.0"
 
   # rails_best_practices is a code metric tool to check the quality of Rails code.
-  spec.add_dependency "rails_best_practices", "~> 1.16.0"
-  spec.add_dependency "pronto-rails_best_practices", "0.6.0"
+  spec.add_dependency "rails_best_practices", "~> 1.17.0"
+  spec.add_dependency "pronto-rails_best_practices", "0.7.0"
 end


### PR DESCRIPTION
This branch bumps up Pronto to 0.7.1 and all its runners to the latest versions. It also contains updates for all libraries related to Pronto runners (Rubocop, Brakeman, etc.).

This branch also cleans up the `ablecop:run_on_circleci` Rake task since Pronto 0.7 now has a formatter to update GitHub's pull request status:

![core-github-pr-status](https://cloud.githubusercontent.com/assets/2877/17997475/c148856e-6ba9-11e6-8f4f-c406b863d82a.png)

The caveat is that it doesn't provide much information, like the following (there's a pull request for adding more info to this so hopefully it will be merged and this is fixed soon):

![core-github-pr-status-infos](https://cloud.githubusercontent.com/assets/2877/17997505/df511436-6ba9-11e6-8a1c-db7a54667973.png)

Another thing is that there were also some changes with how Pronto exits after running its checks. Previously it would return a non-zero exit code for any warnings / errors, but now it won't do that if there are only smaller warnings. able-bot will still report on them, but the pull request status will be green. It doesn't affect how this gem works, though, it's just something to be aware of.
