### PR TITLE
Remove trailing whitespace check in rails_best_practices.yml

### DIFF
--- a/config/rails_best_practices.yml
+++ b/config/rails_best_practices.yml
@@ -22,7 +22,7 @@ OveruseRouteCustomizationsCheck: { customize_count: 3 }
 ProtectMassAssignmentCheck: { }
 RemoveEmptyHelpersCheck: { }
 #RemoveTabCheck: { }
-RemoveTrailingWhitespaceCheck: { }
+#RemoveTrailingWhitespaceCheck: { }
 #RemoveUnusedMethodsInControllersCheck: { except_methods: [] }
 #RemoveUnusedMethodsInHelpersCheck: { except_methods: [] }
 #RemoveUnusedMethodsInModelsCheck: { except_methods: [] }


### PR DESCRIPTION
This pull request removes the check for trailing white space from the rails_best_practices configuration file. RuboCop also has this check, so AbleCop was reporting the error multiple times.

Fixes #28.
