### PR TITLE
Upgrade Pronto and its related runners to the latest version (0.8.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 ## Unreleased
 
 - **AbleCop**: Set Gemfile to use Ruby 2.3.3 for development
+- **AbleCop**: Update development dependency gems (Rake and RSpec) to their latest versions
+- **Pronto**: Update to [0.8.2](https://github.com/mmozuras/pronto/blob/master/CHANGELOG.md#082), and all its associated runners to 0.8.x
+- **RuboCop**: Update to [0.47.1](https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md#0471-2017-01-18)
+- **RuboCop**: Update the default configuration file to support the latest RuboCop version
+- **Brakeman**: Update to [3.5.0](https://github.com/presidentbeef/brakeman/blob/master/CHANGES)
+- **scss-lint**: Update to [0.52.0](https://github.com/brigade/scss-lint/blob/master/CHANGELOG.md#0520)
+- **rails_best_practices**: Update to [1.18.0](https://github.com/railsbp/rails_best_practices/blob/master/CHANGELOG.md#1180-2017-03-01)
+- **AbleCop**: Disabled the [Pronto::RailsSchema](https://github.com/raimondasv/pronto-rails_schema) runner due to currently not having support for Pronto 0.8.x
 
 ## 0.3.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # AbleCop Changelog
 
+## Unreleased
+
+- **AbleCop**: Set Gemfile to use Ruby 2.3.3 for development
+
 ## 0.3.5
 
 - **Pronto**: Update to [0.7.1](https://github.com/mmozuras/pronto/blob/master/CHANGELOG.md#071), and all its associated runners to 0.7.x (#29)

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
-ruby "2.3.1"
+ruby "2.3.3"
 gemspec

--- a/ablecop.gemspec
+++ b/ablecop.gemspec
@@ -38,40 +38,43 @@ MSG
   spec.required_ruby_version = ">= 2.2.0"
 
   spec.add_development_dependency "bundler"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "rake", "~> 12.0"
+  spec.add_development_dependency "rspec", "~> 3.5"
   spec.add_development_dependency "railties", [">= 4.0", "< 4.3"]
   spec.add_development_dependency "generator_spec", "~> 0.9.3"
 
   # Recursively merge hashes - used for merging in configuration overrides.
-  spec.add_dependency "deep_merge", "~> 1.0.1"
+  spec.add_dependency "deep_merge", "~> 1.1.1"
 
   # Pronto posts feedback from its runners to Github.
-  spec.add_dependency "pronto", "~> 0.7.1"
+  spec.add_dependency "pronto", "~> 0.8.2"
 
   # Octokit is required for updating commits / pull requests.
-  spec.add_dependency "octokit", "~> 4.3.0"
+  spec.add_dependency "octokit", "~> 4.6.2"
 
   # Rubocop is a static code analyzer based on our Ruby style guide.
-  spec.add_dependency "rubocop", "~> 0.42.0"
-  spec.add_dependency "pronto-rubocop", "~> 0.7.0"
+  spec.add_dependency "rubocop", "~> 0.47.0"
+  spec.add_dependency "pronto-rubocop", "~> 0.8.0"
 
   # Brakeman scans for security vulenerabilities.
-  spec.add_dependency "brakeman", "~> 3.3.5"
-  spec.add_dependency "pronto-brakeman", "~> 0.7.0"
+  spec.add_dependency "brakeman", "~> 3.5.0"
+  spec.add_dependency "pronto-brakeman", "~> 0.8.0"
 
   # Fasterer will suggest some speed improvements.
   spec.add_dependency "fasterer", "~> 0.3.2"
-  spec.add_dependency "pronto-fasterer", "~> 0.7.0"
+  spec.add_dependency "pronto-fasterer", "~> 0.8.0"
 
   # SCSS Lint is a static code analyzer based on our SCSS style guide.
-  spec.add_dependency "scss_lint", "~> 0.49.0"
-  spec.add_dependency "pronto-scss", "~> 0.7.0"
+  spec.add_dependency "scss_lint", "~> 0.52.0"
+  spec.add_dependency "pronto-scss", "~> 0.8.0"
 
   # Pronto runner for monitoring Rails schema.rb or structure.sql consistency.
-  spec.add_dependency "pronto-rails_schema", "~> 0.7.0"
+  #
+  # TODO: This has been disabled for now while the gem is updated to support
+  # pronto 0.8.0. Once the gem has been updated we can re-enable this.
+  # spec.add_dependency "pronto-rails_schema", "~> 0.7.0"
 
   # rails_best_practices is a code metric tool to check the quality of Rails code.
-  spec.add_dependency "rails_best_practices", "~> 1.17.0"
-  spec.add_dependency "pronto-rails_best_practices", "0.7.0"
+  spec.add_dependency "rails_best_practices", "~> 1.18.0"
+  spec.add_dependency "pronto-rails_best_practices", "0.8.0"
 end

--- a/config/.rubocop.yml
+++ b/config/.rubocop.yml
@@ -265,7 +265,7 @@ Style/BracesAroundHashParameters:
 
 # Indentation of `when`.
 Style/CaseIndentation:
-  IndentWhenRelativeTo: case
+  EnforcedStyle: case
   SupportedStyles:
     - case
     - end
@@ -621,7 +621,7 @@ Style/NonNilCheck:
   # offenses for `!x.nil?` and does no changes that might change behavior.
   IncludeSemanticChanges: false
 
-Style/MethodCallParentheses:
+Style/MethodCallWithoutArgsParentheses:
   Enabled: true
 
 Style/MethodDefParentheses:
@@ -815,7 +815,7 @@ Style/StringMethods:
 
 Style/SpaceAroundBlockParameters:
   EnforcedStyleInsidePipes: no_space
-  SupportedStyles:
+  SupportedStylesInsidePipes:
     - space
     - no_space
 
@@ -884,7 +884,7 @@ Style/TrailingCommaInArguments:
   # If `consistent_comma`, the cop requires a comma after the last argument,
   # for all parenthesized method calls with arguments.
   EnforcedStyleForMultiline: no_comma
-  SupportedStyles:
+  SupportedStylesForMultiline:
     - comma
     - consistent_comma
     - no_comma
@@ -895,7 +895,7 @@ Style/TrailingCommaInLiteral:
   # If `consistent_comma`, the cop requires a comma after the last item of all
   # non-empty array and hash literals.
   EnforcedStyleForMultiline: no_comma
-  SupportedStyles:
+  SupportedStylesForMultiline:
     - comma
     - consistent_comma
     - no_comma
@@ -973,6 +973,12 @@ Metrics/AbcSize:
   # a Float.
   Max: 15
 
+Metrics/BlockLength:
+  Enabled: false
+  CountComments: false  # count full line comments?
+  Max: 25
+  ExcludedMethods: []
+
 Metrics/BlockNesting:
   Max: 3
 
@@ -1025,8 +1031,8 @@ Lint/BlockAlignment:
   # The value `start_of_line` means it should be aligned with the whole
   # expression's starting line.
   # The value `either` means both are allowed.
-  AlignWith: either
-  SupportedStyles:
+  EnforcedStyleAlignWith: either
+  SupportedStylesAlignWith:
     - either
     - start_of_block
     - start_of_line
@@ -1040,8 +1046,8 @@ Lint/EndAlignment:
   # situations, `end` should still be aligned with the keyword.
   # The value `start_of_line` means that `end` should be aligned with the start
   # of the line which the matching keyword appears on.
-  AlignWith: keyword
-  SupportedStyles:
+  EnforcedStyleAlignWith: keyword
+  SupportedStylesAlignWith:
     - keyword
     - variable
     - start_of_line
@@ -1052,8 +1058,8 @@ Lint/DefEndAlignment:
   # The value `start_of_line` means that `end` should be aligned with method
   # calls like `private`, `public`, etc, if present in front of the `def`
   # keyword on the same line.
-  AlignWith: start_of_line
-  SupportedStyles:
+  EnforcedStyleAlignWith: start_of_line
+  SupportedStylesAlignWith:
     - start_of_line
     - def
   AutoCorrect: false


### PR DESCRIPTION
This branch bumps up Pronto to 0.8.2 and all its runners to the latest versions. It also contains updates for all libraries related to Pronto runners (Rubocop, Brakeman, etc.). Specific versions can be found in the changelog.

There were a few changes that needed to be made in the default RuboCop configuration due to deprecations in the latest version of RuboCop. Most of the changes were changing the name of the cops, and in one case I added a new cop in order to disable it since it was on by default.

In this branch, I temporarily disabled the [pronto-rails_schema](https://github.com/raimondasv/pronto-rails_schema) runner because it currently does not have support for the latest version of Pronto. I will be submitting a pull request for that library soon and when the maintainer upgrades the gem, I'll re-enable it separately.

Finally, the Gemfile was bumped up to specify the latest Ruby 2.3.3, as well as updating the development dependencies that were outdated.