### PR TITLE
Disable NotRescueExceptionCheck in rails_best_practices config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - **scss-lint**: Update to [0.52.0](https://github.com/brigade/scss-lint/blob/master/CHANGELOG.md#0520)
 - **rails_best_practices**: Update to [1.18.0](https://github.com/railsbp/rails_best_practices/blob/master/CHANGELOG.md#1180-2017-03-01)
 - **AbleCop**: Disabled the [Pronto::RailsSchema](https://github.com/raimondasv/pronto-rails_schema) runner due to currently not having support for Pronto 0.8.x
+- **rails_best_practices**: Comment out [NotRescueExceptionCheck](https://rails-bestpractices.com/posts/2012/11/01/don-t-rescue-exception-rescue-standarderror/) since RuboCop already does the same
 
 ## 0.3.5
 

--- a/config/rails_best_practices.yml
+++ b/config/rails_best_practices.yml
@@ -15,7 +15,7 @@ MoveCodeIntoModelCheck: { use_count: 2 }
 MoveFinderToNamedScopeCheck: { }
 MoveModelLogicIntoModelCheck: { use_count: 4 }
 NeedlessDeepNestingCheck: { nested_count: 2 }
-NotRescueExceptionCheck: { }
+#NotRescueExceptionCheck: { }
 NotUseDefaultRouteCheck: { }
 NotUseTimeAgoInWordsCheck: { }
 OveruseRouteCustomizationsCheck: { customize_count: 3 }


### PR DESCRIPTION
This branch disables the [NotRescueExceptionCheck](https://rails-bestpractices.com/posts/2012/11/01/don-t-rescue-exception-rescue-standarderror/) check for the rails_best_practices configuration. RuboCop already does the same check, and the error message is a lot clearer in RuboCop, so to avoid getting duplicate messages this one can be safely disabled.