### PR TITLE
Update pronto-rails_schema to 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@
 - **Brakeman**: Update to [3.5.0](https://github.com/presidentbeef/brakeman/blob/master/CHANGES)
 - **scss-lint**: Update to [0.52.0](https://github.com/brigade/scss-lint/blob/master/CHANGELOG.md#0520)
 - **rails_best_practices**: Update to [1.18.0](https://github.com/railsbp/rails_best_practices/blob/master/CHANGELOG.md#1180-2017-03-01)
-- **AbleCop**: Disabled the [Pronto::RailsSchema](https://github.com/raimondasv/pronto-rails_schema) runner due to currently not having support for Pronto 0.8.x
 - **rails_best_practices**: Comment out [NotRescueExceptionCheck](https://rails-bestpractices.com/posts/2012/11/01/don-t-rescue-exception-rescue-standarderror/) since RuboCop already does the same
+- **AbleCop**: Fix issue #31 - Pronto raises exception when pronto-rails_schema raises warning
 
 ## 0.3.5
 

--- a/ablecop.gemspec
+++ b/ablecop.gemspec
@@ -69,10 +69,7 @@ MSG
   spec.add_dependency "pronto-scss", "~> 0.8.0"
 
   # Pronto runner for monitoring Rails schema.rb or structure.sql consistency.
-  #
-  # TODO: This has been disabled for now while the gem is updated to support
-  # pronto 0.8.0. Once the gem has been updated we can re-enable this.
-  # spec.add_dependency "pronto-rails_schema", "~> 0.7.0"
+  spec.add_dependency "pronto-rails_schema", "~> 0.8.0"
 
   # rails_best_practices is a code metric tool to check the quality of Rails code.
   spec.add_dependency "rails_best_practices", "~> 1.18.0"


### PR DESCRIPTION
The [pronto-rails_schema](https://github.com/raimondasv/pronto-rails_schema) gem was updated to support the latest version of Pronto. This pull request updates the gem dependency so we can include it again.

This update also closes #31, which was fixed in https://github.com/mmozuras/pronto/issues/201 and released in Pronto 0.8.1.