### PR TITLE
Update rubocop to its latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # AbleCop Changelog
 
+## Unreleased
+
+- **RuboCop**: Update to [0.48.1](https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md#0481-2017-04-03) (#40)
+
 ## 0.4.1
 
 - **AbleCop**: Change GitHub access token environment variable from `GITHUB_ACCESS_TOKEN` `PRONTO_GITHUB_ACCESS_TOKEN` to reflect changes in Pronto 0.8.0.

--- a/ablecop.gemspec
+++ b/ablecop.gemspec
@@ -53,7 +53,7 @@ MSG
   spec.add_dependency "octokit", "~> 4.6.2"
 
   # Rubocop is a static code analyzer based on our Ruby style guide.
-  spec.add_dependency "rubocop", "~> 0.47.0"
+  spec.add_dependency "rubocop", "~> 0.48.1"
   spec.add_dependency "pronto-rubocop", "~> 0.8.0"
 
   # Brakeman scans for security vulenerabilities.

--- a/ablecop.gemspec
+++ b/ablecop.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 $LOAD_PATH.push File.expand_path("../lib", __FILE__)
 require "ablecop/version"
 
@@ -15,25 +16,24 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.post_install_message = <<-MSG
-Ablecop Setup - Local
-===========================================================================
-You can generate the necessary configuration files to run any code
-analysis locally by running the following command:
+    Ablecop Setup - Local
+    ===========================================================================
+    You can generate the necessary configuration files to run any code
+    analysis locally by running the following command:
 
-    bundle exec rails g ablecop:install
+        bundle exec rails g ablecop:install
 
-Ablecop Setup - CircleCI
-===========================================================================
-To enable CircleCI to run ablecop's checks and comment on commits with each
-push, add the following configuration to your circle.yml configuration:
+    Ablecop Setup - CircleCI
+    ===========================================================================
+    To enable CircleCI to run ablecop's checks and comment on commits with each
+    push, add the following configuration to your circle.yml configuration:
 
-test:
-  pre:
-    - bundle exec rails g ablecop:install
-  post:
-    - RAILS_ENV=development bundle exec rake ablecop:run_on_circleci
-
-MSG
+    test:
+      pre:
+        - bundle exec rails g ablecop:install
+      post:
+        - RAILS_ENV=development bundle exec rake ablecop:run_on_circleci
+  MSG
 
   spec.required_ruby_version = ">= 2.2.0"
 

--- a/lib/ablecop/tasks/ablecop.rake
+++ b/lib/ablecop/tasks/ablecop.rake
@@ -5,7 +5,7 @@ desc "Runs ablecop automatted code review on CircleCI"
 namespace :ablecop do
   desc "Run code analysis for the current commit / pull request on CircleCI"
   task :run_on_circleci do
-    abort("The GitHub access token is missing. Please set the PRONTO_GITHUB_ACCESS_TOKEN environment variable as specified in the README: https://github.com/ableco/ablecop#circleci--github-setup") unless ENV["PRONTO_GITHUB_ACCESS_TOKEN"].present?
+    abort("The GitHub access token is missing. Please set the PRONTO_GITHUB_ACCESS_TOKEN environment variable as specified in the README: https://github.com/ableco/ablecop#circleci--github-setup") if ENV["PRONTO_GITHUB_ACCESS_TOKEN"].blank?
 
     require_pronto_runners
 
@@ -13,7 +13,7 @@ namespace :ablecop do
     # branch for the pull request.
     if ENV["CI_PULL_REQUEST"].present?
       ENV["PULL_REQUEST_ID"] = ENV["CI_PULL_REQUEST"].match("[0-9]+$").to_s
-      abort("Pull Request ID is missing") unless ENV["PULL_REQUEST_ID"].present?
+      abort("Pull Request ID is missing") if ENV["PULL_REQUEST_ID"].blank?
 
       pull_request_formatter = Pronto::Formatter::GithubPullRequestFormatter.new
       status_formatter = Pronto::Formatter::GithubStatusFormatter.new


### PR DESCRIPTION
The rubocop gem was updated to make suggestions based on the project's Rails version.
This pull request updates the gem dependency so we have this functionality available.

For more details please see: https://github.com/bbatsov/rubocop/pull/4107