### PR TITLE
Add VariableNumber style rule

### DIFF
--- a/config/.rubocop.yml
+++ b/config/.rubocop.yml
@@ -948,6 +948,13 @@ Style/VariableName:
     - snake_case
     - camelCase
 
+Style/VariableNumber:
+  EnforcedStyle: snake_case
+  SupportedStyles:
+    - snake_case
+    - normalcase
+    - non_integer
+
 Style/WhileUntilModifier:
   MaxLineLength: 80
 


### PR DESCRIPTION
to enforce snake_case when using numbers as part of the name of a variable.

For example:

# bad

variable1 = 1

# good

variable_1 = 1

See: http://www.rubydoc.info/gems/rubocop/0.43.0/RuboCop/Cop/Style/VariableNumber