### PR TITLE
Updates to code analysis gems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - **Pronto**: Update pronto-rubocop to [0.8.1](https://github.com/mmozuras/pronto-rubocop/pull/24)
 - **Brakeman**: Update to [3.6.1](https://github.com/presidentbeef/brakeman/blob/master/CHANGES)
 - **scss-lint**: Update to [0.53.0](https://github.com/brigade/scss-lint/blob/master/CHANGELOG.md#0530)
+- **AbleCop**: Relax `railties` development dependency.
 
 ## 0.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - **RuboCop**: Update to [0.48.1](https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md#0481-2017-04-03) (#40)
 - **AbleCop**: Support for Ruby 2.4.
+- **Pronto**: Update pronto-rubocop to [0.8.1](https://github.com/mmozuras/pronto-rubocop/pull/24)
 
 ## 0.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - **AbleCop**: Support for Ruby 2.4.
 - **Pronto**: Update pronto-rubocop to [0.8.1](https://github.com/mmozuras/pronto-rubocop/pull/24)
 - **Brakeman**: Update to [3.6.1](https://github.com/presidentbeef/brakeman/blob/master/CHANGES)
+- **scss-lint**: Update to [0.53.0](https://github.com/brigade/scss-lint/blob/master/CHANGELOG.md#0530)
 
 ## 0.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **RuboCop**: Update to [0.48.1](https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md#0481-2017-04-03) (#40)
 - **AbleCop**: Support for Ruby 2.4.
 - **Pronto**: Update pronto-rubocop to [0.8.1](https://github.com/mmozuras/pronto-rubocop/pull/24)
+- **Brakeman**: Update to [3.6.1](https://github.com/presidentbeef/brakeman/blob/master/CHANGES)
 
 ## 0.4.1
 

--- a/ablecop.gemspec
+++ b/ablecop.gemspec
@@ -57,7 +57,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "pronto-rubocop", "~> 0.8.1"
 
   # Brakeman scans for security vulenerabilities.
-  spec.add_dependency "brakeman", "~> 3.5.0"
+  spec.add_dependency "brakeman", "~> 3.6.1"
   spec.add_dependency "pronto-brakeman", "~> 0.8.0"
 
   # Fasterer will suggest some speed improvements.

--- a/ablecop.gemspec
+++ b/ablecop.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "rspec", "~> 3.5"
-  spec.add_development_dependency "railties", [">= 4.0", "< 4.3"]
+  spec.add_development_dependency "railties", [">= 4.0", "< 5.1"]
   spec.add_development_dependency "generator_spec", "~> 0.9.3"
 
   # Recursively merge hashes - used for merging in configuration overrides.

--- a/ablecop.gemspec
+++ b/ablecop.gemspec
@@ -65,7 +65,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "pronto-fasterer", "~> 0.8.0"
 
   # SCSS Lint is a static code analyzer based on our SCSS style guide.
-  spec.add_dependency "scss_lint", "~> 0.52.0"
+  spec.add_dependency "scss_lint", "~> 0.53.0"
   spec.add_dependency "pronto-scss", "~> 0.8.0"
 
   # Pronto runner for monitoring Rails schema.rb or structure.sql consistency.

--- a/ablecop.gemspec
+++ b/ablecop.gemspec
@@ -54,7 +54,7 @@ Gem::Specification.new do |spec|
 
   # Rubocop is a static code analyzer based on our Ruby style guide.
   spec.add_dependency "rubocop", "~> 0.48.1"
-  spec.add_dependency "pronto-rubocop", "~> 0.8.0"
+  spec.add_dependency "pronto-rubocop", "~> 0.8.1"
 
   # Brakeman scans for security vulenerabilities.
   spec.add_dependency "brakeman", "~> 3.5.0"


### PR DESCRIPTION
This pull request updates a few of our main code analysis gems in AbleCop:

- `pronto-rubocop`
- `brakeman`
- `scss_lint`

It also relaxes the `railties` development dependency so we're not locked in to Rails 4.x.