### PR TITLE
Upgrade pronto to 0.9.2 and use new GitHub Pull Request Review formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## Unreleased
 
+- **Pronto**: Update to [0.9.1](https://github.com/mmozuras/pronto/blob/master/CHANGELOG.md#091), and all its associated runners to 0.9.x
 - **RuboCop**: Update to [0.48.1](https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md#0481-2017-04-03) (#40)
-- **AbleCop**: Support for Ruby 2.4.
-- **Pronto**: Update pronto-rubocop to [0.8.1](https://github.com/mmozuras/pronto-rubocop/pull/24)
 - **Brakeman**: Update to [3.6.1](https://github.com/presidentbeef/brakeman/blob/master/CHANGES)
 - **scss-lint**: Update to [0.53.0](https://github.com/brigade/scss-lint/blob/master/CHANGELOG.md#0530)
+- **AbleCop**: Support for Ruby 2.4.
 - **AbleCop**: Relax `railties` development dependency.
 
 ## 0.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- **Pronto**: Update to [0.9.1](https://github.com/mmozuras/pronto/blob/master/CHANGELOG.md#091), and all its associated runners to 0.9.x
+- **Pronto**: Update to [0.9.2](https://github.com/mmozuras/pronto/blob/master/CHANGELOG.md#092), and all its associated runners to 0.9.x
 - **RuboCop**: Update to [0.48.1](https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md#0481-2017-04-03) (#40)
 - **Brakeman**: Update to [3.6.1](https://github.com/presidentbeef/brakeman/blob/master/CHANGES)
 - **scss-lint**: Update to [0.53.0](https://github.com/brigade/scss-lint/blob/master/CHANGELOG.md#0530)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@
 - **RuboCop**: Update to [0.48.1](https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md#0481-2017-04-03) (#40)
 - **Brakeman**: Update to [3.6.1](https://github.com/presidentbeef/brakeman/blob/master/CHANGES)
 - **scss-lint**: Update to [0.53.0](https://github.com/brigade/scss-lint/blob/master/CHANGELOG.md#0530)
-- **AbleCop**: Support for Ruby 2.4.
-- **AbleCop**: Relax `railties` development dependency.
+- **AbleCop**: Support for Ruby 2.4
+- **AbleCop**: Relax `railties` development dependency
+- **AbleCop**: Use new GitHub Pull Request review formatter when running on CircleCI
+- **AbleCop**: Change environment variable used by Pronto to set current pull request information from `PULL_REQUEST_ID` to `PRONTO_PULL_REQUEST_ID`
 
 ## 0.4.1
 

--- a/ablecop.gemspec
+++ b/ablecop.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "deep_merge", "~> 1.1.1"
 
   # Pronto posts feedback from its runners to Github.
-  spec.add_dependency "pronto", "~> 0.9.1"
+  spec.add_dependency "pronto", "~> 0.9.2"
 
   # Octokit is required for updating commits / pull requests.
   spec.add_dependency "octokit", "~> 4.7.0"

--- a/ablecop.gemspec
+++ b/ablecop.gemspec
@@ -47,31 +47,31 @@ Gem::Specification.new do |spec|
   spec.add_dependency "deep_merge", "~> 1.1.1"
 
   # Pronto posts feedback from its runners to Github.
-  spec.add_dependency "pronto", "~> 0.8.2"
+  spec.add_dependency "pronto", "~> 0.9.1"
 
   # Octokit is required for updating commits / pull requests.
-  spec.add_dependency "octokit", "~> 4.6.2"
+  spec.add_dependency "octokit", "~> 4.7.0"
 
   # Rubocop is a static code analyzer based on our Ruby style guide.
   spec.add_dependency "rubocop", "~> 0.48.1"
-  spec.add_dependency "pronto-rubocop", "~> 0.8.1"
+  spec.add_dependency "pronto-rubocop", "~> 0.9.0"
 
   # Brakeman scans for security vulenerabilities.
   spec.add_dependency "brakeman", "~> 3.6.1"
-  spec.add_dependency "pronto-brakeman", "~> 0.8.0"
+  spec.add_dependency "pronto-brakeman", "~> 0.9.0"
 
   # Fasterer will suggest some speed improvements.
   spec.add_dependency "fasterer", "~> 0.3.2"
-  spec.add_dependency "pronto-fasterer", "~> 0.8.0"
+  spec.add_dependency "pronto-fasterer", "~> 0.9.0"
 
   # SCSS Lint is a static code analyzer based on our SCSS style guide.
   spec.add_dependency "scss_lint", "~> 0.53.0"
-  spec.add_dependency "pronto-scss", "~> 0.8.0"
+  spec.add_dependency "pronto-scss", "~> 0.9.1"
 
   # Pronto runner for monitoring Rails schema.rb or structure.sql consistency.
-  spec.add_dependency "pronto-rails_schema", "~> 0.8.0"
+  spec.add_dependency "pronto-rails_schema", "~> 0.9.0"
 
   # rails_best_practices is a code metric tool to check the quality of Rails code.
   spec.add_dependency "rails_best_practices", "~> 1.18.0"
-  spec.add_dependency "pronto-rails_best_practices", "0.8.0"
+  spec.add_dependency "pronto-rails_best_practices", "0.9.0"
 end

--- a/lib/ablecop/tasks/ablecop.rake
+++ b/lib/ablecop/tasks/ablecop.rake
@@ -9,18 +9,18 @@ namespace :ablecop do
 
     require_pronto_runners
 
-    # If CircleCI includes the pull request information, run the code analysis on the
-    # branch for the pull request.
     if ENV["CI_PULL_REQUEST"].present?
-      ENV["PULL_REQUEST_ID"] = ENV["CI_PULL_REQUEST"].match("[0-9]+$").to_s
-      abort("Pull Request ID is missing") if ENV["PULL_REQUEST_ID"].blank?
+      # If CircleCI includes the pull request information, run the code analysis on the
+      # branch for the pull request.
+      ENV["PRONTO_PULL_REQUEST_ID"] = ENV["CI_PULL_REQUEST"].match("[0-9]+$").to_s
+      abort("Pull Request ID is missing") if ENV["PRONTO_PULL_REQUEST_ID"].blank?
 
-      pull_request_formatter = Pronto::Formatter::GithubPullRequestFormatter.new
+      pull_request_review_formatter = Pronto::Formatter::GithubPullRequestReviewFormatter.new
       status_formatter = Pronto::Formatter::GithubStatusFormatter.new
-      Pronto.run("origin/master", ".", [pull_request_formatter, status_formatter])
-    # If CircleCI does not include the pull request information, run the
-    # code analysis on the current commit.
+      Pronto.run("origin/master", ".", [pull_request_review_formatter, status_formatter])
     else
+      # If CircleCI does not include the pull request information, run the
+      # code analysis on the current commit.
       formatter = Pronto::Formatter::GithubFormatter.new
       Pronto.run("origin/master", ".", formatter)
     end


### PR DESCRIPTION
This pull request upgrades Pronto to the latest version ([0.9.2](https://github.com/mmozuras/pronto/blob/master/CHANGELOG.md#092)) and all its associated runners to their latest versions as well.

Also updated: Pronto 0.9 adds the ability to use GitHub's Reviews API to group the comments together as a review, as opposed to comments throughout the pull request, so I updated the Rask task that's run on CircleCI to use the new formatter.