### PR TITLE
Disable Style/GuardClause Enforcement

### DIFF
--- a/config/.rubocop.yml
+++ b/config/.rubocop.yml
@@ -511,10 +511,8 @@ Style/FrozenStringLiteralComment:
 Style/GlobalVars:
   AllowedVariables: []
 
-# `MinBodyLength` defines the number of lines of the a body of an if / unless
-# needs to have to trigger this cop
 Style/GuardClause:
-  MinBodyLength: 1
+  Enabled: false
 
 Style/HashSyntax:
   EnforcedStyle: ruby19


### PR DESCRIPTION
This PR disables `Style/GuardClause` following the conversation at https://github.com/ableco/ablecop/issues/47.