### PR TITLE
Change Hex notation to uppercase

### DIFF
--- a/config/.scss-lint.yml
+++ b/config/.scss-lint.yml
@@ -72,7 +72,7 @@ linters:
 
   HexNotation:
     enabled: true
-    style: lowercase # or 'uppercase'
+    style: uppercase
 
   HexValidation:
     enabled: true


### PR DESCRIPTION
As it is the conventional way to write them, at least for programmers.