### PR TITLE
Do not make Rubocop enforce any EOF style

### DIFF
--- a/config/.rubocop.yml
+++ b/config/.rubocop.yml
@@ -870,12 +870,6 @@ Style/SymbolProc:
   IgnoredMethods:
     - respond_to
 
-Style/TrailingBlankLines:
-  EnforcedStyle: final_newline
-  SupportedStyles:
-    - final_newline
-    - final_blank_line
-
 Style/TrailingCommaInArguments:
   # If `comma`, the cop requires a comma after the last argument, but only for
   # parenthesized method calls where each argument is on its own line.


### PR DESCRIPTION
Although POSIX requires [files to end with an empty newline](http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_206), this isn't a live or die issue. The excess of rules of Ablecop adds more noise than valuable feedback. Accordingly I would like to remove this rule so that Ablecop doesn't care either way. Thoughts?

(This could be handled automatically in the git commit hook on the git server if we hosted our git public repository)