### PR TITLE
Allow up to 4 shorthand properties

### DIFF
--- a/config/.scss-lint.yml
+++ b/config/.scss-lint.yml
@@ -167,7 +167,7 @@ linters:
 
   Shorthand:
     enabled: true
-    allowed_shorthands: [1, 2, 3]
+    allowed_shorthands: [1, 2, 3, 4]
 
   SingleLinePerProperty:
     enabled: true


### PR DESCRIPTION
Four shorthand properties for declarations like `padding` and `margin` should be allowed.

It's common that paddings and margins use four different values for each side of an element. If three are allowed, I don't see why we wouldn't allow all four to be used.

Going even further the `background` and `font` property allow for more values which are better to have in one single readable line rather than multiple lines which can be organized in any order.