### PR TITLE
Upgrade Pronto, code analyzers and gems to latest versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # AbleCop Changelog
 
+## Unreleased
+
+- **RuboCop**: Disable `Style/GuardClause` rule (#48)
+
 ## 0.5.0
 
 - **Pronto**: Update to [0.9.2](https://github.com/mmozuras/pronto/blob/master/CHANGELOG.md#092), and all its associated runners to 0.9.x (#45)

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 ruby "2.4.1"
 # Specify ruby_parser's version in order to include support for Ruby 2.4
-gem "ruby_parser", "~> 3.9.0"
+gem "ruby_parser", "~> 3.10"
 gemspec

--- a/ablecop.gemspec
+++ b/ablecop.gemspec
@@ -47,17 +47,17 @@ Gem::Specification.new do |spec|
   spec.add_dependency "deep_merge", "~> 1.1.1"
 
   # Pronto posts feedback from its runners to Github.
-  spec.add_dependency "pronto", "~> 0.9.2"
+  spec.add_dependency "pronto", "~> 0.9.5"
 
   # Octokit is required for updating commits / pull requests.
   spec.add_dependency "octokit", "~> 4.7.0"
 
   # Rubocop is a static code analyzer based on our Ruby style guide.
-  spec.add_dependency "rubocop", "~> 0.48.1"
+  spec.add_dependency "rubocop", "~> 0.49.1"
   spec.add_dependency "pronto-rubocop", "~> 0.9.0"
 
   # Brakeman scans for security vulenerabilities.
-  spec.add_dependency "brakeman", "~> 3.6.1"
+  spec.add_dependency "brakeman", "~> 3.7.2"
   spec.add_dependency "pronto-brakeman", "~> 0.9.0"
 
   # Fasterer will suggest some speed improvements.
@@ -65,13 +65,13 @@ Gem::Specification.new do |spec|
   spec.add_dependency "pronto-fasterer", "~> 0.9.0"
 
   # SCSS Lint is a static code analyzer based on our SCSS style guide.
-  spec.add_dependency "scss_lint", "~> 0.53.0"
+  spec.add_dependency "scss_lint", "~> 0.54.0"
   spec.add_dependency "pronto-scss", "~> 0.9.1"
 
   # Pronto runner for monitoring Rails schema.rb or structure.sql consistency.
   spec.add_dependency "pronto-rails_schema", "~> 0.9.0"
 
   # rails_best_practices is a code metric tool to check the quality of Rails code.
-  spec.add_dependency "rails_best_practices", "~> 1.18.0"
+  spec.add_dependency "rails_best_practices", "~> 1.19.0"
   spec.add_dependency "pronto-rails_best_practices", "0.9.0"
 end

--- a/ablecop.gemspec
+++ b/ablecop.gemspec
@@ -39,8 +39,8 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 12.0"
-  spec.add_development_dependency "rspec", "~> 3.5"
-  spec.add_development_dependency "railties", [">= 4.0", "< 5.1"]
+  spec.add_development_dependency "rspec", "~> 3.6"
+  spec.add_development_dependency "railties", [">= 4.0", "< 5.2"]
   spec.add_development_dependency "generator_spec", "~> 0.9.3"
 
   # Recursively merge hashes - used for merging in configuration overrides.


### PR DESCRIPTION
This pull request upgrade Pronto to the latest version, [0.9.5](https://github.com/prontolabs/pronto/blob/master/CHANGELOG.md#095). It also upgrades all the code analyzers (Rubocop, Brakeman, scss-lint, rails_best_practices) to their latest versions, and some development dependencies as well.