### PR TITLE
Do not enforce 'percent' notation for arrays in RuboCop

### DIFF
--- a/config/.rubocop.yml
+++ b/config/.rubocop.yml
@@ -859,7 +859,6 @@ Layout/SpaceInsideStringInterpolation:
     - no_space
 
 Style/SymbolArray:
-  EnforcedStyle: percent
   SupportedStyles:
     - percent
     - brackets
@@ -952,7 +951,6 @@ Style/WhileUntilModifier:
 
 # WordArray enforces how array literals of word-like strings should be expressed.
 Style/WordArray:
-  EnforcedStyle: percent
   SupportedStyles:
     # percent style: %w(word1 word2)
     - percent


### PR DESCRIPTION
This pull request removes the enforcement of using the percent notation in Ruby for both arrays of symbols and arrays of words. This was the default in RuboCop. Now we can use any of these without RuboCop complaining:

```ruby
# Word arrays
['one', 'two']
%w[one two]

# Symbol arrays
[:one, :two]
%i[one two]
```

In reality, there's no difference in performance and there's not really any benefit in syntax or readability, so I think it's best to not enforce this rule since the warning gets triggered constantly in a lot of our projects.