### PR TITLE
Upgrade to rubocop 0.51.0

### DIFF
--- a/ablecop.gemspec
+++ b/ablecop.gemspec
@@ -36,10 +36,10 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.2.0"
 
   spec.add_development_dependency "bundler"
+  spec.add_development_dependency "generator_spec", "~> 0.9.3"
+  spec.add_development_dependency "railties", [">= 4.0", "< 5.2"]
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "rspec", "~> 3.6"
-  spec.add_development_dependency "railties", [">= 4.0", "< 5.2"]
-  spec.add_development_dependency "generator_spec", "~> 0.9.3"
 
   # Recursively merge hashes - used for merging in configuration overrides.
   spec.add_dependency "deep_merge", "~> 1.1.1"
@@ -52,6 +52,8 @@ Gem::Specification.new do |spec|
 
   # Rubocop is a static code analyzer based on our Ruby style guide.
   spec.add_dependency "rubocop", "~> 0.51.0"
+
+  # Pronto posts offenses as GitHub comments.
   spec.add_dependency "pronto-rubocop", "~> 0.9.0"
 
   # Brakeman scans for security vulenerabilities.
@@ -63,13 +65,13 @@ Gem::Specification.new do |spec|
   spec.add_dependency "pronto-fasterer", "~> 0.9.0"
 
   # SCSS Lint is a static code analyzer based on our SCSS style guide.
-  spec.add_dependency "scss_lint", "~> 0.54.0"
   spec.add_dependency "pronto-scss", "~> 0.9.1"
+  spec.add_dependency "scss_lint", "~> 0.54.0"
 
   # Pronto runner for monitoring Rails schema.rb or structure.sql consistency.
   spec.add_dependency "pronto-rails_schema", "~> 0.9.0"
 
   # rails_best_practices is a code metric tool to check the quality of Rails code.
-  spec.add_dependency "rails_best_practices", "~> 1.19.0"
   spec.add_dependency "pronto-rails_best_practices", "0.9.0"
+  spec.add_dependency "rails_best_practices", "~> 1.19.0"
 end

--- a/ablecop.gemspec
+++ b/ablecop.gemspec
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 $LOAD_PATH.push File.expand_path("../lib", __FILE__)
 require "ablecop/version"
 

--- a/ablecop.gemspec
+++ b/ablecop.gemspec
@@ -53,7 +53,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "octokit", "~> 4.7.0"
 
   # Rubocop is a static code analyzer based on our Ruby style guide.
-  spec.add_dependency "rubocop", "~> 0.49.1"
+  spec.add_dependency "rubocop", "~> 0.51.0"
   spec.add_dependency "pronto-rubocop", "~> 0.9.0"
 
   # Brakeman scans for security vulenerabilities.

--- a/config/.rubocop.yml
+++ b/config/.rubocop.yml
@@ -619,7 +619,7 @@ Style/MethodDefParentheses:
     - require_no_parentheses
     - require_no_parentheses_except_multiline
 
-Style/MethodName:
+Naming/MethodName:
   EnforcedStyle: snake_case
   SupportedStyles:
     - snake_case
@@ -695,7 +695,7 @@ Style/PercentQLiterals:
     - lower_case_q # Use %q when possible, %Q when necessary
     - upper_case_q # Always use %Q
 
-Style/PredicateName:
+Naming/PredicateName:
   # Predicate name prefixes.
   NamePrefix:
     - is_
@@ -923,13 +923,13 @@ Style/TrivialAccessors:
     - to_s
     - to_sym
 
-Style/VariableName:
+Naming/VariableName:
   EnforcedStyle: snake_case
   SupportedStyles:
     - snake_case
     - camelCase
 
-Style/VariableNumber:
+Naming/VariableNumber:
   EnforcedStyle: snake_case
   SupportedStyles:
     - snake_case

--- a/config/.rubocop.yml
+++ b/config/.rubocop.yml
@@ -425,16 +425,6 @@ Layout/EmptyLinesAroundModuleBody:
     - empty_lines
     - no_empty_lines
 
-# Checks whether the source file has a utf-8 encoding comment or not
-# AutoCorrectEncodingComment must match the regex
-# /#.*coding\s?[:=]\s?(?:UTF|utf)-8/
-Style/Encoding:
-  EnforcedStyle: always
-  SupportedStyles:
-    - when_needed
-    - always
-  AutoCorrectEncodingComment: '# encoding: utf-8'
-
 Layout/ExtraSpacing:
   # When true, allows most uses of extra spacing if the intent is to align
   # things with the previous or next line, not counting empty lines or comment
@@ -443,7 +433,7 @@ Layout/ExtraSpacing:
   # When true, forces the alignment of = in assignments on consecutive lines.
   ForceEqualSignAlignment: false
 
-Style/FileName:
+Naming/FileName:
   # File names listed in AllCops:Include are excluded by default. Add extra
   # excludes here.
   Exclude: []


### PR DESCRIPTION
Updates minimum rubocop version from `0.49.1` to `0.51.0`.

- [x] Set rubocop minimum version to 0.51.0
- [x] Remove deprecated Style/Encoding rules
- [x] Update to new Style rules that now use Naming prefix
- [x] Remove unnecessary utf-8 encoding comment
- [x] Adhere to gemspec alphabetical order rule

Details in the rubocop [CHANGELOG](https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md).