### PR TITLE
Rubocop: Disable check for top-level documentation

### DIFF
--- a/config/.rubocop.yml
+++ b/config/.rubocop.yml
@@ -378,10 +378,7 @@ Style/Copyright:
 # By default, Rubocop enforces class-level documentation. Doesn't always
 # make sense in Rails apps.
 Style/Documentation:
-  Exclude:
-    - 'config/**/*'
-    - 'app/controllers/**/*'
-    - 'app/views/**/*'
+  Enabled: false
 
 # Multi-line method chaining should be done with leading dots.
 Layout/DotPosition:


### PR DESCRIPTION
This pull request is for disabling Rubocop checking for top-level comments to document classes and modules (http://www.rubydoc.info/github/bbatsov/rubocop/Rubocop/Cop/Style/Documentation).

In short, AbleCop will raise a warning in this scenario (assuming that `User` has code in it):

```ruby
class User
  # Class methods here
end
```

While there are some cases where documenting a class / module is useful in a Rails app, I feel that for most of our normal projects this creates too much noise since the majority of our classes _shouldn't_ need to have documentation to explain their purpose.