### PR TITLE
Set up TargetRubyVersion config to Ruby 2.3 for RuboCop

### DIFF
--- a/config/.rubocop.yml
+++ b/config/.rubocop.yml
@@ -61,7 +61,7 @@ AllCops:
   CacheRootDirectory: /tmp
   # What version of the Ruby interpreter is the inspected code intended to
   # run on? (If there is more than one, set this to the lowest version.)
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
 
 # Indent private/protected/public as deep as method definitions
 Layout/AccessModifierIndentation:

--- a/config/.rubocop.yml
+++ b/config/.rubocop.yml
@@ -483,6 +483,7 @@ Style/FormatString:
     - percent
 
 Style/FrozenStringLiteralComment:
+  Enabled: false
   EnforcedStyle: when_needed
   SupportedStyles:
     # `when_needed` will add the frozen string literal comment to files


### PR DESCRIPTION
This pull request bumps up the `TargetRubyVersion` in RuboCop to specify Ruby 2.3, as suggested by @joerodrig. Our projects are all using Ruby 2.3 and up so we can safely set this here.

Closes #58.