### PR TITLE
Exclude RuboCop from checking the node_modules directory

### DIFF
--- a/config/.rubocop.yml
+++ b/config/.rubocop.yml
@@ -23,6 +23,7 @@ AllCops:
     - 'vendor/**/*'
     - 'db/migrate/*'
     - 'db/schema.rb'
+    - 'node_modules/**/*'
   # Default formatter will be used if no -f/--format option is given.
   DefaultFormatter: progress
   # Cop names are not displayed in offense messages by default. Change behavior


### PR DESCRIPTION
This pull request excludes RuboCop from checking the `node_modules` directory in the default configuration, as requested by @joerodrig.

Closes #57.