### PR TITLE
Set minimum Ruby version to >= 2.3.0 and gem updates (RuboCop, Brakeman, fasterer, scss_lint, dev and supporting libraries)

### DIFF
--- a/ablecop.gemspec
+++ b/ablecop.gemspec
@@ -51,7 +51,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "octokit", "~> 4.7.0"
 
   # Rubocop is a static code analyzer based on our Ruby style guide.
-  spec.add_dependency "rubocop", "~> 0.51.0"
+  spec.add_dependency "rubocop", "~> 0.52.1"
 
   # Pronto posts offenses as GitHub comments.
   spec.add_dependency "pronto-rubocop", "~> 0.9.0"

--- a/ablecop.gemspec
+++ b/ablecop.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
         - RAILS_ENV=development bundle exec rake ablecop:run_on_circleci
   MSG
 
-  spec.required_ruby_version = ">= 2.2.0"
+  spec.required_ruby_version = ">= 2.3.0"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "generator_spec", "~> 0.9.3"

--- a/ablecop.gemspec
+++ b/ablecop.gemspec
@@ -66,7 +66,7 @@ Gem::Specification.new do |spec|
 
   # SCSS Lint is a static code analyzer based on our SCSS style guide.
   spec.add_dependency "pronto-scss", "~> 0.9.1"
-  spec.add_dependency "scss_lint", "~> 0.54.0"
+  spec.add_dependency "scss_lint", "~> 0.56.0"
 
   # Pronto runner for monitoring Rails schema.rb or structure.sql consistency.
   spec.add_dependency "pronto-rails_schema", "~> 0.9.0"

--- a/ablecop.gemspec
+++ b/ablecop.gemspec
@@ -61,7 +61,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "pronto-brakeman", "~> 0.9.0"
 
   # Fasterer will suggest some speed improvements.
-  spec.add_dependency "fasterer", "~> 0.3.2"
+  spec.add_dependency "fasterer", "~> 0.4.0"
   spec.add_dependency "pronto-fasterer", "~> 0.9.0"
 
   # SCSS Lint is a static code analyzer based on our SCSS style guide.

--- a/ablecop.gemspec
+++ b/ablecop.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.6"
 
   # Recursively merge hashes - used for merging in configuration overrides.
-  spec.add_dependency "deep_merge", "~> 1.1.1"
+  spec.add_dependency "deep_merge", "~> 1.2.1"
 
   # Pronto posts feedback from its runners to Github.
   spec.add_dependency "pronto", "~> 0.9.5"

--- a/ablecop.gemspec
+++ b/ablecop.gemspec
@@ -57,7 +57,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "pronto-rubocop", "~> 0.9.0"
 
   # Brakeman scans for security vulenerabilities.
-  spec.add_dependency "brakeman", "~> 4.1.1"
+  spec.add_dependency "brakeman", "~> 4.2.0"
   spec.add_dependency "pronto-brakeman", "~> 0.9.0"
 
   # Fasterer will suggest some speed improvements.

--- a/ablecop.gemspec
+++ b/ablecop.gemspec
@@ -57,7 +57,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "pronto-rubocop", "~> 0.9.0"
 
   # Brakeman scans for security vulenerabilities.
-  spec.add_dependency "brakeman", "~> 3.7.2"
+  spec.add_dependency "brakeman", "~> 4.1.1"
   spec.add_dependency "pronto-brakeman", "~> 0.9.0"
 
   # Fasterer will suggest some speed improvements.

--- a/ablecop.gemspec
+++ b/ablecop.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "generator_spec", "~> 0.9.3"
   spec.add_development_dependency "railties", [">= 4.0", "< 5.2"]
   spec.add_development_dependency "rake", "~> 12.0"
-  spec.add_development_dependency "rspec", "~> 3.6"
+  spec.add_development_dependency "rspec", "~> 3.7"
 
   # Recursively merge hashes - used for merging in configuration overrides.
   spec.add_dependency "deep_merge", "~> 1.2.1"

--- a/config/.rubocop.yml
+++ b/config/.rubocop.yml
@@ -512,9 +512,6 @@ Style/HashSyntax:
 # Force hashes that have a symbol value to use hash rockets
   UseHashRocketsWithSymbolValues: false
 
-Style/IfUnlessModifier:
-  MaxLineLength: 80
-
 Layout/IndentationConsistency:
   # The difference between `rails` and `normal` is that the `rails` style
   # prescribes that in classes and modules the `protected` and `private`
@@ -934,9 +931,6 @@ Naming/VariableNumber:
     - snake_case
     - normalcase
     - non_integer
-
-Style/WhileUntilModifier:
-  MaxLineLength: 80
 
 # WordArray enforces how array literals of word-like strings should be expressed.
 Style/WordArray:


### PR DESCRIPTION
This pull request sets AbleCop's minimum required Ruby version to 2.3.0 or greater, which makes sense to do since we're targeting Ruby 2.3 and above in other gems like RuboCop (#59).

The pull request also updates lots of gems related to AbleCop's main functionality as well as development and other supporting gems. The main ones are the following:

- Upgrade RuboCop to 0.52.1 and clean up default configuration to remove rules that are no longer supported.
- Upgrade Brakeman to 4.2.0.
- Upgrade fasterer to 0.4.0.
- Upgrade scss_lint to 0.56.0.